### PR TITLE
Create retrieve storage API, fix wrong return type for retrieve, list…

### DIFF
--- a/src/main/java/co/uiza/apiwrapper/model/Entity.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Entity.java
@@ -6,8 +6,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import co.uiza.apiwrapper.exception.BadRequestException;
 import co.uiza.apiwrapper.exception.UizaException;
 import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
 
 public class Entity extends ApiResource {
 
@@ -86,6 +88,10 @@ public class Entity extends ApiResource {
    *
    */
   public static JsonObject retrieveEntity(String id) throws UizaException {
+    if (id == null || id.isEmpty()) {
+      throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+    }
+
     Map<String, Object> entityParams = new HashMap<>();
     entityParams.put("id", id);
     JsonElement response =
@@ -108,6 +114,10 @@ public class Entity extends ApiResource {
   *
   */
   public static JsonArray listEntity(Map<String, Object> entityParams) throws UizaException {
+    if (entityParams.containsKey("id")) {
+      throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+    }
+
     JsonElement response =
         request(RequestMethod.GET, buildRequestURL(CLASS_DEFAULT_PATH), entityParams);
 

--- a/src/main/java/co/uiza/apiwrapper/model/Storage.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Storage.java
@@ -1,0 +1,29 @@
+package co.uiza.apiwrapper.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+public class Storage extends ApiResource {
+
+  private static final String CLASS_DEFAULT_PATH = "media/storage";
+
+  public static JsonObject retrieveStorage(String id) throws UizaException {
+    if (id == null || id.isEmpty()) {
+      throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+    }
+
+    Map<String, Object> storageParams = new HashMap<>();
+    storageParams.put("id", id);
+
+    JsonElement response =
+        request(RequestMethod.GET, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
+
+    return checkResponseType(response);
+  }
+}

--- a/src/test/java/co/uiza/apiwrapper/TestBase.java
+++ b/src/test/java/co/uiza/apiwrapper/TestBase.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 public class TestBase {
   protected final String TEST_URL = "uiza.co/test";
   protected final String ENTITY_ID = "16ab25d3-fd0f-4568-8aa0-0339bbfd674f";
+  protected final String STORAGE_ID = "013130d7-abba-466b-bc47-c86c628a305e";
 
   @Rule
   protected ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/co/uiza/apiwrapper/model/storage/RetrieveStorageTest.java
+++ b/src/test/java/co/uiza/apiwrapper/model/storage/RetrieveStorageTest.java
@@ -1,0 +1,158 @@
+package co.uiza.apiwrapper.model.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.TestBase;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.ClientException;
+import co.uiza.apiwrapper.exception.InternalServerException;
+import co.uiza.apiwrapper.exception.NotFoundException;
+import co.uiza.apiwrapper.exception.ServerException;
+import co.uiza.apiwrapper.exception.ServiceUnavailableException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.exception.UnauthorizedException;
+import co.uiza.apiwrapper.exception.UnprocessableException;
+import co.uiza.apiwrapper.model.Storage;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.ApiResource.RequestMethod;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class RetrieveStorageTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", STORAGE_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("id", STORAGE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Storage.retrieveStorage(STORAGE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, STORAGE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, STORAGE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, STORAGE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, STORAGE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e =
+        new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, STORAGE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, STORAGE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, STORAGE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, STORAGE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(STORAGE_ID, STORAGE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.retrieveStorage(STORAGE_ID);
+  }
+}


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/221542

## What's this PR do ?

- [x] Implement Retrieve storage API.
- [x] Fix wrong return for retrieve, and list methods.

## Library

## Impacted Areas in Application

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```java
import static co.uiza.apiwrapper.model.Storage.retrieveStorage;

Uiza.apiDomain = "<YOUR_API_DOMAIN>";    
Uiza.apiKey = "<YOUR_API_KEY>";

JsonObject response = retrieveStorage("<YOUR_STORAGE_ID>");
```