### PR TITLE
Create add storage API with unit test

### DIFF
--- a/src/main/java/co/uiza/apiwrapper/model/Storage.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Storage.java
@@ -35,36 +35,10 @@ public class Storage extends ApiResource {
   /**
    * You can sync your storage (FTP, AWS S3) with UIZA.
    * After sync, you can select your content easier from your storage to create entity.
-   * Create a FTP storage
    *
-   * @param storageParams
+   * @param storageParams a Map object storing key-value pairs of request parameter
    */
-  public static JsonObject createFtpStorage(Map<String, Object> storageParams)
-      throws UizaException {
-    if (storageParams != null) {
-      storageParams.put("storageType", StorageType.FTP.getStorageType());
-    }
-
-    JsonElement response =
-        request(RequestMethod.POST, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
-    String id = getId((JsonObject) checkResponseType(response));
-
-    return retrieveStorage(id);
-  }
-
-  /**
-   * You can sync your storage (FTP, AWS S3) with UIZA.
-   * After sync, you can select your content easier from your storage to create entity.
-   * Create a AWS S3 storage
-   *
-   * @param storageParams
-   */
-  public static JsonObject createAwsS3Storage(Map<String, Object> storageParams)
-      throws UizaException {
-    if (storageParams != null) {
-      storageParams.put("storageType", StorageType.S3.getStorageType());
-    }
-
+  public static JsonObject addStorage(Map<String, Object> storageParams) throws UizaException {
     JsonElement response =
         request(RequestMethod.POST, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
     String id = getId((JsonObject) checkResponseType(response));

--- a/src/main/java/co/uiza/apiwrapper/model/Storage.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Storage.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
 import co.uiza.apiwrapper.exception.BadRequestException;
 import co.uiza.apiwrapper.exception.UizaException;
 import co.uiza.apiwrapper.net.ApiResource;
@@ -13,6 +14,70 @@ public class Storage extends ApiResource {
 
   private static final String CLASS_DEFAULT_PATH = "media/storage";
 
+  public enum StorageType {
+    @SerializedName("ftp")
+    FTP("ftp"),
+
+    @SerializedName("s3")
+    S3("s3");
+
+    private final String storageType;
+
+    public String getStorageType() {
+      return storageType;
+    }
+
+    private StorageType(String storageType) {
+      this.storageType = storageType;
+    }
+  }
+
+  /**
+   * You can sync your storage (FTP, AWS S3) with UIZA.
+   * After sync, you can select your content easier from your storage to create entity.
+   * Create a FTP storage
+   *
+   * @param storageParams
+   */
+  public static JsonObject createFtpStorage(Map<String, Object> storageParams)
+      throws UizaException {
+    if (storageParams != null) {
+      storageParams.put("storageType", StorageType.FTP.getStorageType());
+    }
+
+    JsonElement response =
+        request(RequestMethod.POST, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
+    String id = getId((JsonObject) checkResponseType(response));
+
+    return retrieveStorage(id);
+  }
+
+  /**
+   * You can sync your storage (FTP, AWS S3) with UIZA.
+   * After sync, you can select your content easier from your storage to create entity.
+   * Create a AWS S3 storage
+   *
+   * @param storageParams
+   */
+  public static JsonObject createAwsS3Storage(Map<String, Object> storageParams)
+      throws UizaException {
+    if (storageParams != null) {
+      storageParams.put("storageType", StorageType.S3.getStorageType());
+    }
+
+    JsonElement response =
+        request(RequestMethod.POST, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
+    String id = getId((JsonObject) checkResponseType(response));
+
+    return retrieveStorage(id);
+  }
+
+  /**
+   * Get information of your added storage (FTP or AWS S3)
+   *
+   * @param id An id of storage to retrieve
+   *
+   */
   public static JsonObject retrieveStorage(String id) throws UizaException {
     if (id == null || id.isEmpty()) {
       throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);

--- a/src/test/java/co/uiza/apiwrapper/model/storage/AddStorageTest.java
+++ b/src/test/java/co/uiza/apiwrapper/model/storage/AddStorageTest.java
@@ -66,39 +66,7 @@ public class AddStorageTest extends TestBase {
     Mockito.when(ApiResource.getId(Mockito.any())).thenCallRealMethod();
     Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
 
-    JsonObject actual = Storage.createFtpStorage(paramsOfCreate);
-    Assert.assertEquals(expectedOfRetrieve, actual);
-  }
-
-  @Test
-  public void testCreateAwsS3StorageSuccess() throws UizaException {
-    JsonObject expectedOfCreate = new JsonObject();
-    expectedOfCreate.addProperty("id", STORAGE_ID);
-
-    Map<String, Object> paramsOfCreate = new HashMap<>();
-    paramsOfCreate.put("name", "Name");
-    paramsOfCreate.put("host", "Host");
-    paramsOfCreate.put("port", "Port");
-    paramsOfCreate.put("type", "ftp");
-
-    JsonObject expectedOfRetrieve = new JsonObject();
-    expectedOfRetrieve.addProperty("id", STORAGE_ID);
-    expectedOfRetrieve.addProperty("name", "Name");
-    expectedOfRetrieve.addProperty("host", "Host");
-    expectedOfRetrieve.addProperty("port", "Port");
-    expectedOfRetrieve.addProperty("type", "ftp");
-
-    Map<String, Object> paramsOfRetrieve = new HashMap<>();
-    paramsOfRetrieve.put("id", STORAGE_ID);
-
-    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, paramsOfCreate))
-        .thenReturn(expectedOfCreate);
-    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, paramsOfRetrieve))
-        .thenReturn(expectedOfRetrieve);
-    Mockito.when(ApiResource.getId(Mockito.any())).thenCallRealMethod();
-    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
-
-    JsonObject actual = Storage.createFtpStorage(paramsOfCreate);
+    JsonObject actual = Storage.addStorage(paramsOfCreate);
     Assert.assertEquals(expectedOfRetrieve, actual);
   }
 
@@ -110,7 +78,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -121,7 +89,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -132,7 +100,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -143,7 +111,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -154,7 +122,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -166,7 +134,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -177,7 +145,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -188,7 +156,7 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 
   @Test
@@ -199,6 +167,6 @@ public class AddStorageTest extends TestBase {
     expectedException.expect(e.getClass());
     expectedException.expectMessage(e.getMessage());
 
-    Storage.createFtpStorage(null);
+    Storage.addStorage(null);
   }
 }

--- a/src/test/java/co/uiza/apiwrapper/model/storage/AddStorageTest.java
+++ b/src/test/java/co/uiza/apiwrapper/model/storage/AddStorageTest.java
@@ -1,0 +1,204 @@
+package co.uiza.apiwrapper.model.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.TestBase;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.ClientException;
+import co.uiza.apiwrapper.exception.InternalServerException;
+import co.uiza.apiwrapper.exception.NotFoundException;
+import co.uiza.apiwrapper.exception.ServerException;
+import co.uiza.apiwrapper.exception.ServiceUnavailableException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.exception.UnauthorizedException;
+import co.uiza.apiwrapper.exception.UnprocessableException;
+import co.uiza.apiwrapper.model.Storage;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.ApiResource.RequestMethod;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class AddStorageTest extends TestBase {
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testCreateFtpStorageSuccess() throws UizaException {
+    JsonObject expectedOfCreate = new JsonObject();
+    expectedOfCreate.addProperty("id", STORAGE_ID);
+
+    Map<String, Object> paramsOfCreate = new HashMap<>();
+    paramsOfCreate.put("name", "Name");
+    paramsOfCreate.put("host", "Host");
+    paramsOfCreate.put("port", "Port");
+    paramsOfCreate.put("type", "Type");
+
+    JsonObject expectedOfRetrieve = new JsonObject();
+    expectedOfRetrieve.addProperty("id", STORAGE_ID);
+    expectedOfRetrieve.addProperty("name", "Name");
+    expectedOfRetrieve.addProperty("host", "Host");
+    expectedOfRetrieve.addProperty("port", "Port");
+    expectedOfRetrieve.addProperty("type", "Type");
+
+    Map<String, Object> paramsOfRetrieve = new HashMap<>();
+    paramsOfRetrieve.put("id", STORAGE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, paramsOfCreate))
+        .thenReturn(expectedOfCreate);
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, paramsOfRetrieve))
+        .thenReturn(expectedOfRetrieve);
+    Mockito.when(ApiResource.getId(Mockito.any())).thenCallRealMethod();
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Storage.createFtpStorage(paramsOfCreate);
+    Assert.assertEquals(expectedOfRetrieve, actual);
+  }
+
+  @Test
+  public void testCreateAwsS3StorageSuccess() throws UizaException {
+    JsonObject expectedOfCreate = new JsonObject();
+    expectedOfCreate.addProperty("id", STORAGE_ID);
+
+    Map<String, Object> paramsOfCreate = new HashMap<>();
+    paramsOfCreate.put("name", "Name");
+    paramsOfCreate.put("host", "Host");
+    paramsOfCreate.put("port", "Port");
+    paramsOfCreate.put("type", "ftp");
+
+    JsonObject expectedOfRetrieve = new JsonObject();
+    expectedOfRetrieve.addProperty("id", STORAGE_ID);
+    expectedOfRetrieve.addProperty("name", "Name");
+    expectedOfRetrieve.addProperty("host", "Host");
+    expectedOfRetrieve.addProperty("port", "Port");
+    expectedOfRetrieve.addProperty("type", "ftp");
+
+    Map<String, Object> paramsOfRetrieve = new HashMap<>();
+    paramsOfRetrieve.put("id", STORAGE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, paramsOfCreate))
+        .thenReturn(expectedOfCreate);
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, paramsOfRetrieve))
+        .thenReturn(expectedOfRetrieve);
+    Mockito.when(ApiResource.getId(Mockito.any())).thenCallRealMethod();
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Storage.createFtpStorage(paramsOfCreate);
+    Assert.assertEquals(expectedOfRetrieve, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, "", 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, "", 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, "", 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, "", 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, "", 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, "", 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, "", 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException("", "", 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.createFtpStorage(null);
+  }
+}


### PR DESCRIPTION
## Related Tickets
* https://dev.framgia.com/issues/221541

## What's this PR do ?
* [x]  Implement Create storage API (FTP and AWS S3).
* [x]  Implement JUnit test for Create storage API.

## Library
## Impacted Areas in Application
## Performance
## Checklist
* [x]  It was tested in local success?
* [x]  Fill link PR into ticket and the opposite
* [x]  Note reason, scope of influence, solution into ticket
* [x]  Validate UI/Model/API

## Deploy Notes
## Notes
```java
import static co.uiza.apiwrapper.model.Storage.createFtpStorage;
import static co.uiza.apiwrapper.model.Storage.createAwsS3Storage;

Uiza.apiDomain = "<YOUR_API_DOMAIN>";    
Uiza.apiKey = "<YOUR_API_KEY>";

Map<String, Object> params = new HashMap<>();
params.put("name", "<STORAGE_NAME>");
params.put("host", "<STORAGE_HOST>");
params.put("port", "<STORAGE_PORT>);

JsonObject res = createFtpStorage(params);
 or 
JsonObject res = createAwsS3Storage(params);
```