### PR TITLE
Create update storage API with unit test

### DIFF
--- a/src/main/java/co/uiza/apiwrapper/model/Storage.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Storage.java
@@ -65,4 +65,22 @@ public class Storage extends ApiResource {
 
     return checkResponseType(response);
   }
+
+  /**
+   * Update storage's information.
+   *
+   * @param id An id of storage to update
+   * @param storageParams a Map object storing key-value pairs of request parameter
+   *
+   */
+  public static JsonObject updateStorage(String id, Map<String, Object> storageParams)
+      throws UizaException {
+    if (storageParams == null) {
+      storageParams = new HashMap<>();
+    }
+    storageParams.put("id", id);
+    request(RequestMethod.PUT, buildRequestURL(CLASS_DEFAULT_PATH), storageParams);
+
+    return retrieveStorage(id);
+  }
 }

--- a/src/test/java/co/uiza/apiwrapper/model/storage/UpdateStorageTest.java
+++ b/src/test/java/co/uiza/apiwrapper/model/storage/UpdateStorageTest.java
@@ -1,0 +1,174 @@
+package co.uiza.apiwrapper.model.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.TestBase;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.ClientException;
+import co.uiza.apiwrapper.exception.InternalServerException;
+import co.uiza.apiwrapper.exception.NotFoundException;
+import co.uiza.apiwrapper.exception.ServerException;
+import co.uiza.apiwrapper.exception.ServiceUnavailableException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.exception.UnauthorizedException;
+import co.uiza.apiwrapper.exception.UnprocessableException;
+import co.uiza.apiwrapper.model.Storage;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.ApiResource.RequestMethod;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class UpdateStorageTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", STORAGE_ID);
+    params.put("name", "Name");
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expectedOfUpdate = new JsonObject();
+    expectedOfUpdate.addProperty("id", STORAGE_ID);
+
+    Map<String, Object> paramsOfUpdate = new HashMap<>();
+    paramsOfUpdate.put("id", STORAGE_ID);
+    paramsOfUpdate.put("name", "Name");
+    paramsOfUpdate.put("storageType", "ftp");
+
+    JsonObject expectedOfRetrieve = new JsonObject();
+    expectedOfRetrieve.addProperty("id", STORAGE_ID);
+    expectedOfRetrieve.addProperty("name", "Name");
+
+    Map<String, Object> paramsOfRetrieve = new HashMap<>();
+    paramsOfRetrieve.put("id", STORAGE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, paramsOfUpdate))
+        .thenReturn(expectedOfUpdate);
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, paramsOfRetrieve))
+        .thenReturn(expectedOfRetrieve);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Storage.updateStorage(STORAGE_ID, params);
+    Assert.assertEquals(expectedOfRetrieve, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, STORAGE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, STORAGE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, STORAGE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, STORAGE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e =
+        new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, STORAGE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, STORAGE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, STORAGE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, STORAGE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(STORAGE_ID, STORAGE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.PUT, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Storage.updateStorage(STORAGE_ID, params);
+  }
+}


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/221543

## What's this PR do ?

- [x] Implement update storage API
- [x] Implement unit test for update storage API

## Library
## Impacted Areas in Application
## Performance
## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
## Notes
```java
import static co.uiza.apiwrapper.model.Storage.updateStorage;

Uiza.apiDomain = "<YOUR_WORKSPACE_API_DOMAIN>";
Uiza.apiKey = "<YOUR_API_KEY>";

Map<String, Object> params = new HashMap<>();
params.put("name", "FTP Uiza");
params.put("host", "ftp-example.uiza.io");
params.put("port", "21");
params.put("type", "ftp");

JsonObject storage = udpateStorage("<storage-id>", params);
```