### PR TITLE
Create retrieve category API with unit test

### DIFF
--- a/src/main/java/co/uiza/apiwrapper/model/Category.java
+++ b/src/main/java/co/uiza/apiwrapper/model/Category.java
@@ -1,0 +1,34 @@
+package co.uiza.apiwrapper.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+public class Category extends ApiResource {
+
+  private static final String CLASS_DEFAULT_PATH = "media/metadata";
+
+  /**
+   * Get detail of category
+   *
+   * @param id An id of category to retrieve
+   *
+   */
+  public static JsonObject retrieveCategory(String id) throws UizaException {
+    if (id == null || id.isEmpty()) {
+      throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+    }
+
+    Map<String, Object> categoryParams = new HashMap<>();
+    categoryParams.put("id", id);
+    JsonElement response =
+        request(RequestMethod.GET, buildRequestURL(CLASS_DEFAULT_PATH), categoryParams);
+
+    return checkResponseType(response);
+  }
+}

--- a/src/test/java/co/uiza/apiwrapper/TestBase.java
+++ b/src/test/java/co/uiza/apiwrapper/TestBase.java
@@ -7,6 +7,7 @@ public class TestBase {
   protected final String TEST_URL = "uiza.co/test";
   protected final String ENTITY_ID = "16ab25d3-fd0f-4568-8aa0-0339bbfd674f";
   protected final String STORAGE_ID = "013130d7-abba-466b-bc47-c86c628a305e";
+  protected final String CATEGORY_ID = "32e8a1f4-e3b6-4369-a30d-60c6715896d1";
 
   @Rule
   protected ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/co/uiza/apiwrapper/model/category/RetrieveCategoryTest.java
+++ b/src/test/java/co/uiza/apiwrapper/model/category/RetrieveCategoryTest.java
@@ -1,0 +1,159 @@
+package co.uiza.apiwrapper.model.category;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import co.uiza.apiwrapper.TestBase;
+import co.uiza.apiwrapper.exception.BadRequestException;
+import co.uiza.apiwrapper.exception.ClientException;
+import co.uiza.apiwrapper.exception.InternalServerException;
+import co.uiza.apiwrapper.exception.NotFoundException;
+import co.uiza.apiwrapper.exception.ServerException;
+import co.uiza.apiwrapper.exception.ServiceUnavailableException;
+import co.uiza.apiwrapper.exception.UizaException;
+import co.uiza.apiwrapper.exception.UnauthorizedException;
+import co.uiza.apiwrapper.exception.UnprocessableException;
+import co.uiza.apiwrapper.model.Category;
+import co.uiza.apiwrapper.net.ApiResource;
+import co.uiza.apiwrapper.net.ApiResource.RequestMethod;
+import co.uiza.apiwrapper.net.util.ErrorMessage;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class RetrieveCategoryTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", CATEGORY_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("id", CATEGORY_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Category.retrieveCategory(CATEGORY_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, CATEGORY_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, CATEGORY_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, CATEGORY_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e =
+        new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, CATEGORY_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e =
+        new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, CATEGORY_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, CATEGORY_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, CATEGORY_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, CATEGORY_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(CATEGORY_ID, CATEGORY_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Category.retrieveCategory(CATEGORY_ID);
+  }
+}


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/221546

## What's this PR do ?

- [x] Implement retrieve category API.
- [x] Implement unit test for retrieve category API.

## Library
## Impacted Areas in Application
## Performance
## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
## Notes
```java
import static co.uiza.apiwrapper.model.Category.retrieveCategory;

Uiza.apiDomain = "<YOUR_WORKSPACE_API_DOMAIN>";
Uiza.apiKey = "<YOUR_API_KEY>";

JsonObject category = retrieveCategory("<category-id>");
```