### PR TITLE
Implement GET methods for Live with unit tests

### DIFF
--- a/src/main/java/io/uiza/model/Live.java
+++ b/src/main/java/io/uiza/model/Live.java
@@ -1,0 +1,64 @@
+package io.uiza.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.UizaException;
+import io.uiza.net.ApiResource;
+import io.uiza.net.util.ErrorMessage;
+
+public class Live extends ApiResource {
+  private static final String CLASS_DEFAULT_PATH = "live/entity";
+  private static final String LIVE_VIEW_PATH = "tracking/current-view";
+  private static final String RECORD_PATH = "dvr";
+
+  /**
+   * Retrieves the details of an existing event.
+   *
+   * @param id An id of live event to retrieve
+   *
+   */
+  public static JsonObject retrieve(String id) throws UizaException {
+    if (id == null || id.isEmpty()) {
+      throw new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+    }
+
+    Map<String, Object> liveParams = new HashMap<>();
+    liveParams.put("id", id);
+    JsonElement response =
+        request(RequestMethod.GET, buildRequestURL(CLASS_DEFAULT_PATH), liveParams);
+
+    return checkResponseType(response);
+  }
+
+  /**
+   * Get a live view status.
+   * This view only show when event has been started and being processing.
+   *
+   * @param id An id of live event to get view
+   *
+   */
+  public static JsonObject getView(String id) throws UizaException {
+    String path_extension = String.format("%s/%s", CLASS_DEFAULT_PATH, LIVE_VIEW_PATH);
+    Map<String, Object> liveParams = new HashMap<>();
+    liveParams.put("id", id);
+    JsonElement response = request(RequestMethod.GET, buildRequestURL(path_extension), liveParams);
+
+    return checkResponseType(response);
+  }
+
+  /**
+   * Retrieves list of recorded file after streamed
+   * (only available when your live event has turned on Record feature)
+   *
+   */
+  public static JsonArray listRecorded() throws UizaException {
+    String path_extension = String.format("%s/%s", CLASS_DEFAULT_PATH, RECORD_PATH);
+    JsonElement response = request(RequestMethod.GET, buildRequestURL(path_extension), null);
+
+    return checkResponseType(response);
+  }
+}

--- a/src/test/java/io/uiza/test/TestBase.java
+++ b/src/test/java/io/uiza/test/TestBase.java
@@ -9,6 +9,7 @@ public class TestBase {
   protected final String STORAGE_ID = "013130d7-abba-466b-bc47-c86c628a305e";
   protected final String CATEGORY_ID = "32e8a1f4-e3b6-4369-a30d-60c6715896d1";
   protected final String RELATION_ID = "737a3683-d5ec-4440-9021-721135141ecb";
+  protected final String LIVE_ID = "7fc80748-e3f9-4ff7-bb8a-cf37e8918239";
 
   @Rule
   protected ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/io/uiza/test/model/live/GetViewLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/GetViewLiveTest.java
@@ -1,0 +1,157 @@
+package io.uiza.test.model.live;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class GetViewLiveTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", LIVE_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("id", LIVE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Live.getView(LIVE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, LIVE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, LIVE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, LIVE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, LIVE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, LIVE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, LIVE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, LIVE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, LIVE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(LIVE_ID, LIVE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.getView(LIVE_ID);
+  }
+}

--- a/src/test/java/io/uiza/test/model/live/ListRecordedLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/ListRecordedLiveTest.java
@@ -1,0 +1,149 @@
+package io.uiza.test.model.live;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonArray;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class ListRecordedLiveTest extends TestBase {
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonArray expected = new JsonArray();
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonArray actual = Live.listRecorded();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, "", 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, "", 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, "", 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, "", 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, "", 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, "", 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, "", 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException("", "", 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.listRecorded();
+  }
+}

--- a/src/test/java/io/uiza/test/model/live/RetrieveLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/RetrieveLiveTest.java
@@ -1,0 +1,157 @@
+package io.uiza.test.model.live;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class RetrieveLiveTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", LIVE_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("id", LIVE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Live.retrieve(LIVE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, LIVE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, LIVE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, LIVE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, LIVE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, LIVE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, LIVE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, LIVE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, LIVE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(LIVE_ID, LIVE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.retrieve(LIVE_ID);
+  }
+}


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/221561
- https://dev.framgia.com/issues/221568
- https://dev.framgia.com/issues/221574

## What's this PR do ?

- [x] Implement retrieve live
- [x] Implement get view of live
- [x] Implement list all recorded files of live
- [x] Implement unit tests for above methods

## Library
*(List maven plugins, library third party add new include version)*

## Impacted Areas in Application
*(List features, api, models or services that this PR will affect)*

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
*(List commands, environment variables need configurations after deploy)*

## Notes
*(Other notes)*
```
import io.uiza.model.Live;

Uiza.apiDomain = "<YOUR_WORKSPACE_API_DOMAIN>";
Uiza.apiKey = "<YOUR_API_KEY>";

JsonObject live = retrieve("<live-id>");
```