### PR TITLE
Implement POST methods for Live with unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <maven.gpg>1.5</maven.gpg>
     <nexus.staging.maven>1.6.7</nexus.staging.maven>
     <gson.version>2.8.5</gson.version>
+    <jacoco.version>0.8.3</jacoco.version>
     <junit.version>4.12</junit.version>
     <powermock.version>1.7.4</powermock.version>
   </properties>
@@ -103,6 +104,12 @@
       <artifactId>powermock-core</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>${jacoco.version}</version>
     </dependency>
   </dependencies>
 
@@ -167,6 +174,25 @@
             <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/io/uiza/model/Live.java
+++ b/src/main/java/io/uiza/model/Live.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
 import io.uiza.exception.BadRequestException;
 import io.uiza.exception.UizaException;
 import io.uiza.net.ApiResource;
@@ -12,8 +13,98 @@ import io.uiza.net.util.ErrorMessage;
 
 public class Live extends ApiResource {
   private static final String CLASS_DEFAULT_PATH = "live/entity";
+  private static final String FEED_PATH = "feed";
   private static final String LIVE_VIEW_PATH = "tracking/current-view";
   private static final String RECORD_PATH = "dvr";
+  private static final String VOD_PATH = "dvr/convert-to-vod";
+
+  public enum Mode {
+    @SerializedName("pull")
+    PULL("pull"),
+
+    @SerializedName("push")
+    PUSH("push");
+
+    private String mode;
+
+    private Mode(String mode) {
+      this.mode = mode;
+    }
+
+    public String getMode() {
+      return mode;
+    }
+  }
+
+  public enum Encode {
+    @SerializedName("0")
+    NO_ENCODE(0),
+
+    @SerializedName("1")
+    ENCODE(1);
+
+    private int encode;
+
+    private Encode(int encode) {
+      this.encode = encode;
+    }
+
+    public int getEncode() {
+      return encode;
+    }
+  }
+
+  public enum Dvr {
+    @SerializedName("0")
+    NO_RECORD(0),
+
+    @SerializedName("1")
+    ACTIVE_RECORD(1);
+
+    private int dvr;
+
+    private Dvr(int dvr) {
+      this.dvr = dvr;
+    }
+
+    public int getDvr() {
+      return dvr;
+    }
+  }
+
+  public enum ResourceMode {
+    @SerializedName("single")
+    SINGLE("single"),
+
+    @SerializedName("redundant")
+    REDUNDANT("redundant");
+
+    private String resourceMode;
+
+    private ResourceMode(String resourceMode) {
+      this.resourceMode = resourceMode;
+    }
+
+    public String getResourceMode() {
+      return resourceMode;
+    }
+  }
+
+  /**
+   * Create a live streaming and manage the live streaming input (output).
+   * A live stream can be set up and start later or start right after set up.
+   * Live Channel Minutes counts when the event starts.
+   *
+   * @param liveParams a Map object storing key-value pairs of request parameter
+   *
+   */
+  public static JsonObject create(Map<String, Object> liveParams) throws UizaException {
+    JsonElement response =
+        request(RequestMethod.POST, buildRequestURL(CLASS_DEFAULT_PATH), liveParams);
+    String id = getId((JsonObject) checkResponseType(response));
+
+    return retrieve(id);
+  }
 
   /**
    * Retrieves the details of an existing event.
@@ -30,6 +121,22 @@ public class Live extends ApiResource {
     liveParams.put("id", id);
     JsonElement response =
         request(RequestMethod.GET, buildRequestURL(CLASS_DEFAULT_PATH), liveParams);
+
+    return checkResponseType(response);
+  }
+
+  /**
+   * Start a live event that has been create success.
+   * The Live channel minute start count whenever the event start success.
+   *
+   * @param id An id of live event to start feeding
+   *
+   */
+  public static JsonObject startFeed(String id) throws UizaException {
+    String path_extension = String.format("%s/%s", CLASS_DEFAULT_PATH, FEED_PATH);
+    Map<String, Object> liveParams = new HashMap<>();
+    liveParams.put("id", id);
+    JsonElement response = request(RequestMethod.POST, buildRequestURL(path_extension), liveParams);
 
     return checkResponseType(response);
   }
@@ -58,6 +165,21 @@ public class Live extends ApiResource {
   public static JsonArray listRecorded() throws UizaException {
     String path_extension = String.format("%s/%s", CLASS_DEFAULT_PATH, RECORD_PATH);
     JsonElement response = request(RequestMethod.GET, buildRequestURL(path_extension), null);
+
+    return checkResponseType(response);
+  }
+
+  /**
+   * Convert recorded file into VOD entity.
+   * After converted, your file can be stream via Uiza's CDN.
+   *
+   * @param id An id of live event to convert into VOD
+   */
+  public static JsonObject convertToVod(String id) throws UizaException {
+    String path_extension = String.format("%s/%s", CLASS_DEFAULT_PATH, VOD_PATH);
+    Map<String, Object> liveParams = new HashMap<>();
+    liveParams.put("id", id);
+    JsonElement response = request(RequestMethod.POST, buildRequestURL(path_extension), liveParams);
 
     return checkResponseType(response);
   }

--- a/src/test/java/io/uiza/test/model/live/ConvertToVodLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/ConvertToVodLiveTest.java
@@ -1,0 +1,159 @@
+package io.uiza.test.model.live;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class ConvertToVodLiveTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", LIVE_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("message",
+        "Your entity started publish, check process status with this entity ID");
+    expected.addProperty("entityId", LIVE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Live.convertToVod(LIVE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, LIVE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, LIVE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, LIVE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, LIVE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, LIVE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, LIVE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, LIVE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, LIVE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(LIVE_ID, LIVE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.convertToVod(LIVE_ID);
+  }
+}

--- a/src/test/java/io/uiza/test/model/live/CreateLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/CreateLiveTest.java
@@ -1,0 +1,171 @@
+package io.uiza.test.model.live;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class CreateLiveTest extends TestBase {
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expectedOfCreate = new JsonObject();
+    expectedOfCreate.addProperty("id", LIVE_ID);
+
+    Map<String, Object> paramsOfCreate = new HashMap<>();
+    paramsOfCreate.put("name", "Name");
+    paramsOfCreate.put("mode", "push");
+    paramsOfCreate.put("encode", 0);
+    paramsOfCreate.put("dvr", 0);
+    paramsOfCreate.put("linkStream", "");
+    paramsOfCreate.put("resourceMode", "single");
+
+    JsonObject expectedOfRetrieve = new JsonObject();
+    expectedOfRetrieve.addProperty("id", LIVE_ID);
+    expectedOfRetrieve.addProperty("name", "Name");
+
+    Map<String, Object> paramsOfRetrieve = new HashMap<>();
+    paramsOfRetrieve.put("id", LIVE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, paramsOfCreate))
+        .thenReturn(expectedOfCreate);
+    Mockito.when(ApiResource.request(RequestMethod.GET, TEST_URL, paramsOfRetrieve))
+        .thenReturn(expectedOfRetrieve);
+    Mockito.when(ApiResource.getId(Mockito.any())).thenCallRealMethod();
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Live.create(paramsOfCreate);
+    Assert.assertEquals(expectedOfRetrieve, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, "", 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, "", 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, "", 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, "", 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, "", 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, "", 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, "", 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, "", 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException("", "", 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, null)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.create(null);
+  }
+}

--- a/src/test/java/io/uiza/test/model/live/StartFeedLiveTest.java
+++ b/src/test/java/io/uiza/test/model/live/StartFeedLiveTest.java
@@ -1,0 +1,159 @@
+package io.uiza.test.model.live;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.gson.JsonObject;
+import io.uiza.exception.BadRequestException;
+import io.uiza.exception.ClientException;
+import io.uiza.exception.InternalServerException;
+import io.uiza.exception.NotFoundException;
+import io.uiza.exception.ServerException;
+import io.uiza.exception.ServiceUnavailableException;
+import io.uiza.exception.UizaException;
+import io.uiza.exception.UnauthorizedException;
+import io.uiza.exception.UnprocessableException;
+import io.uiza.model.Live;
+import io.uiza.net.ApiResource;
+import io.uiza.net.ApiResource.RequestMethod;
+import io.uiza.net.util.ErrorMessage;
+import io.uiza.test.TestBase;
+
+@PowerMockIgnore("javax.net.ssl.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiResource.class)
+public class StartFeedLiveTest extends TestBase {
+
+  private Map<String, Object> params;
+
+  @Before
+  public void setUp() throws Exception {
+    params = new HashMap<>();
+    params.put("id", LIVE_ID);
+
+    PowerMockito.mockStatic(ApiResource.class);
+    Mockito.when(ApiResource.buildRequestURL(Mockito.any())).thenReturn(TEST_URL);
+  }
+
+  @Test
+  public void testSuccess() throws UizaException {
+    JsonObject expected = new JsonObject();
+    expected.addProperty("message",
+        "Your entity started publish, check process status with this entity ID");
+    expected.addProperty("entityId", LIVE_ID);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenReturn(expected);
+    Mockito.when(ApiResource.checkResponseType(Mockito.any())).thenCallRealMethod();
+
+    JsonObject actual = Live.startFeed(LIVE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testFailedThrowsBadRequestException() throws UizaException {
+    UizaException e = new BadRequestException(ErrorMessage.BAD_REQUEST_ERROR, LIVE_ID, 400);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnauthorizedException() throws UizaException {
+    UizaException e = new UnauthorizedException(ErrorMessage.UNAUTHORIZED_ERROR, LIVE_ID, 401);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsNotFoundException() throws UizaException {
+    UizaException e = new NotFoundException(ErrorMessage.NOT_FOUND_ERROR, LIVE_ID, 404);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUnprocessableException() throws UizaException {
+    UizaException e = new UnprocessableException(ErrorMessage.UNPROCESSABLE_ERROR, LIVE_ID, 422);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsInternalServerException() throws UizaException {
+    UizaException e = new InternalServerException(ErrorMessage.INTERNAL_SERVER_ERROR, LIVE_ID, 500);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServiceUnavailableException() throws UizaException {
+    UizaException e =
+        new ServiceUnavailableException(ErrorMessage.SERVICE_UNAVAILABLE_ERROR, LIVE_ID, 503);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsClientException() throws UizaException {
+    UizaException e = new ClientException(ErrorMessage.CLIENT_ERROR, LIVE_ID, 450);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsServerException() throws UizaException {
+    UizaException e = new ServerException(ErrorMessage.SERVER_ERROR, LIVE_ID, 550);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+
+  @Test
+  public void testFailedThrowsUizaException() throws UizaException {
+    UizaException e = new UizaException(LIVE_ID, LIVE_ID, 300);
+
+    Mockito.when(ApiResource.request(RequestMethod.POST, TEST_URL, params)).thenThrow(e);
+    expectedException.expect(e.getClass());
+    expectedException.expectMessage(e.getMessage());
+
+    Live.startFeed(LIVE_ID);
+  }
+}


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/221559
- https://dev.framgia.com/issues/221566
- https://dev.framgia.com/issues/221570

## What's this PR do ?

- [x] Implement create a live event
- [x] Implement start a live feed
- [x] Implement convert into VOD
- [x] Implement unit tests for above methods

## Library
*(List maven plugins, library third party add new include version)*

## Impacted Areas in Application
*(List features, api, models or services that this PR will affect)*

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
*(List commands, environment variables need configurations after deploy)*

## Notes
```
import io.uiza.model.Live;

Uiza.apiDomain = "<YOUR_WORKSPACE_API_DOMAIN>";
Uiza.apiKey = "<YOUR_API_KEY>";

Map<String, Object> params = new HashMap<>();
params.put("name", "<your-live-event-name>");
params.put("mode", Live.PULL.getMode());
params.put("encode", Live.ENCODE.getEncode());
params.put("dvr", Live.ACTIVE_RECORD.getDvr());
params.put("linkStream", "");
params.put("resourceMode", Live.SINGLE.getResourceMode());

JsonObject live = Live.create(params);
```