### PR TITLE
Update APIs for Category, Callback, Storage and Live to version 4

### DIFF
--- a/src/main/java/io/uiza/model/Category.java
+++ b/src/main/java/io/uiza/model/Category.java
@@ -14,8 +14,8 @@ import io.uiza.net.ApiResource;
 import io.uiza.net.util.ErrorMessage;
 
 /**
- * This API wrapper helps you managing your entities easier by splitting category into 3 types:
- * folder, playlist and tag.
+ * This API wrapper helps you managing your entities easier by splitting category into 4 types:
+ * folder, playlist, category, and tag.
  */
 public class Category extends ApiResource {
 
@@ -29,6 +29,9 @@ public class Category extends ApiResource {
 
     @SerializedName("playlist")
     PLAYLIST("playlist"),
+
+    @SerializedName("category")
+    CATEGORY("category"),
 
     @SerializedName("tag")
     TAG("tag");
@@ -47,7 +50,7 @@ public class Category extends ApiResource {
 
   /**
    * Create category for entity for easier management. Category use to group all the same entities
-   * into a group (like folder, playlist, or tag).
+   * into a group (like folder, playlist, category, or tag).
    *
    * @param categoryParams a Map object storing key-value pairs of request parameter
    * @return created category JSON object

--- a/src/main/java/io/uiza/model/Live.java
+++ b/src/main/java/io/uiza/model/Live.java
@@ -44,6 +44,37 @@ public class Live extends ApiResource {
     }
   }
 
+  public enum Status {
+    @SerializedName("init")
+    INIT("init"),
+
+    @SerializedName("start")
+    START("start"),
+
+    @SerializedName("stop")
+    STOP("stop"),
+
+    @SerializedName("error")
+    ERROR("error"),
+
+    @SerializedName("in-process")
+    IN_PROCESS("in-process"),
+
+    @SerializedName("not-streaming")
+    NOT_STREAMING("not-streaming");
+
+    private final String val;
+
+    private Status(String val) {
+      this.val = val;
+    }
+
+    @Override
+    public String toString() {
+      return val;
+    }
+  }
+
   public enum Encode {
     @SerializedName("0")
     NO_ENCODE(0),
@@ -72,6 +103,24 @@ public class Live extends ApiResource {
     private final int val;
 
     private Dvr(int val) {
+      this.val = val;
+    }
+
+    public int getVal() {
+      return val;
+    }
+  }
+
+  public enum Drm {
+    @SerializedName("0")
+    NO_RECORD(0),
+
+    @SerializedName("1")
+    ACTIVE_RECORD(1);
+
+    private final int val;
+
+    private Drm(int val) {
       this.val = val;
     }
 

--- a/src/main/java/io/uiza/model/Storage.java
+++ b/src/main/java/io/uiza/model/Storage.java
@@ -24,6 +24,12 @@ public class Storage extends ApiResource {
     @SerializedName("ftp")
     FTP("ftp"),
 
+    @SerializedName("s3-compatible")
+    S3_COMPATIBLE("s3-compatible"),
+
+    @SerializedName("s3-uiza")
+    S3_UIZA("s3-uiza"),
+
     @SerializedName("s3")
     S3("s3");
 

--- a/src/main/java/io/uiza/net/MainUizaResponseGetter.java
+++ b/src/main/java/io/uiza/net/MainUizaResponseGetter.java
@@ -106,7 +106,12 @@ public class MainUizaResponseGetter implements UizaResponseGetter {
         raiseMalformedJsonError(response.body(), responseCode, response.requestId());
       }
 
-      return data;
+      if (data == null || data.isJsonNull()) {
+        throw new UizaException(responseBody.get("message").toString(), response.requestId(),
+            responseCode);
+      } else {
+        return data;
+      }
     } finally {
       if (allowedToSetTtl && originalDnsCacheTtl != null) {
         java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, originalDnsCacheTtl);


### PR DESCRIPTION
## Related Tickets

- [#229026](https://dev.framgia.com/issues/229026)
- [#229032](https://dev.framgia.com/issues/229032)
- [#229033](https://dev.framgia.com/issues/229033)
- [#229034](https://dev.framgia.com/issues/229034)

## What's this PR do ?

- [x] Update entity APIs from version 3 to 4
- [x] Update live APIs from version 3 to 4
- [x] Update category APIs from version 3 to 4
- [x] Update callback APIs from version 3 to 4

## Library
*(List maven plugins, library third party add new include version)*

## Impacted Areas in Application
*(List features, api, models or services that this PR will affect)*

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
*(List commands, environment variables need configurations after deploy)*

## Notes

### Media Storage
- Uiza doc thiếu param `host` required
### Media Callback
- craete entity callback -> typo trên doc
- create mất 1 khoảng thời gian để setup callback -> lỗi 502 bad gateway hoặc lỗi 503 Service Temporarily Unavailable nếu gọi API khác trong lúc server down
### Live 
- get live/entity thiếu param `id` optional trong doc cho phần retrieve
- post live feed start -> trường hợp mode là pull thì param pullInfo là required chứ không optional, object pullInfo không rõ ràng là object gì
- post convert-to-vod -> object trả về là null json object chứ không phải trả về lỗi như bên v3